### PR TITLE
Fix completion being unable to be deserialized by pickle

### DIFF
--- a/dspy/primitives/prediction.py
+++ b/dspy/primitives/prediction.py
@@ -68,6 +68,8 @@ class Completions:
         return self._completions[key]
 
     def __getattr__(self, name):
+        if name == "_completions":
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
         if name in self._completions:
             return self._completions[name]
 


### PR DESCRIPTION
# Description
- Fix bug in `Completions.__getattr__` which would prevent pickling-unpickling as attempting to access `_completions` on an unitialized instance will lead to an infinite recursion error.

# Test
```python
import pickle
from dspy.primitives.prediction import Completions

c = Completions([])
data = pickle.dumps(c)
pickle.loads(data)
```

In `main`, this will error with:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/dspy/dspy/primitives/prediction.py", line 71, in __getattr__
    if name in self._completions:
  File "/path/dspy/dspy/primitives/prediction.py", line 71, in __getattr__
    if name in self._completions:
  File "/path/dspy/dspy/primitives/prediction.py", line 71, in __getattr__
    if name in self._completions:
  [Previous line repeated 995 more times]
RecursionError: maximum recursion depth exceeded
```