### PR TITLE
Fix Retry `load_state`

### DIFF
--- a/dspy/predict/retry.py
+++ b/dspy/predict/retry.py
@@ -80,3 +80,7 @@ class Retry(Predict):
         self.original_signature = self.module.extended_signature if isinstance(self.module, dspy.ChainOfThought) else self.module.signature
         self.new_signature = self._create_new_signature(self.original_signature)
         return self
+
+    def dump_state(self, save_verbose=None):
+        # Dump the data from the underlying module instead so that it can be loaded back properly
+        return self.module.dump_state(save_verbose)

--- a/dspy/predict/retry.py
+++ b/dspy/predict/retry.py
@@ -73,3 +73,10 @@ class Retry(Predict):
             trace = dsp.settings.trace
             trace.append((self, {**kwargs}, pred))
         return pred
+
+    def load_state(self, state, use_legacy_loading=False):
+        # Override load state to ensure our new signature is based off the latest module state
+        self.module = self.module.load_state(state, use_legacy_loading)
+        self.original_signature = self.module.extended_signature if isinstance(self.module, dspy.ChainOfThought) else self.module.signature
+        self.new_signature = self._create_new_signature(self.original_signature)
+        return self


### PR DESCRIPTION
# Description
- Ensure `Retry` loads the state of the inner module properly

# Context
- Nested modules get wrapped in `Retry` as part of `assert_transform_module` and then don't load their signatures properly from a file

# Test
```python

import pathlib
import functools

import dspy
from dspy.primitives.assertions import assert_transform_module, backtrack_handler


class QuestionAnswerer(dspy.Module):
    def __init__(self):
        super().__init__()
        self.module = dspy.Predict("question -> answer")

    def forward(self, *args, **kwargs):
        return self.module(*args, **kwargs)


class QuestionAnswererWithRetry(dspy.Module):
    def __init__(self):
        super().__init__()
        self.module = assert_transform_module(
            module=QuestionAnswerer(),
            assertion_handler=functools.partial(
                backtrack_handler,
                max_backtracks=2,
            ),
        )

    def forward(self, *args, **kwargs):
        return self.module(*args, **kwargs)


SAVED_MODULE = """
{
  "module.module": {
    "lm": null,
    "traces": [],
    "train": [],
    "demos": [],
    "signature": {
      "instructions": "Answer correctly",
      "fields": [
        {
          "prefix": "Question:",
          "description": "${question}"
        },
        {
          "prefix": "Answer:",
          "description": "${answer}"
        }
      ]
    }
  },
  "metadata": {
    "dependency_versions": {
      "python": "3.10.15",
      "dspy": "2.5.43",
      "cloudpickle": "3.1.1"
    }
  }
}
""".strip()



if __name__ == "__main__":
    localpath = "localpath.json"
    pathlib.Path(localpath).write_text(SAVED_MODULE)
    retrier = QuestionAnswererWithRetry()
    assert "Answer correctly" not in retrier.module.module.new_signature.instructions

    retrier.load(localpath)

    assert "Answer correctly" in retrier.module.module.new_signature.instructions
```