### PR TITLE
Copy over demos when wrapping predict

### DIFF
--- a/dspy/predict/retry.py
+++ b/dspy/predict/retry.py
@@ -10,6 +10,7 @@ class Retry(Predict):
     def __init__(self, module):
         super().__init__(module.signature)
         self.module = module
+        self.demos = module.demos
         self.original_signature = module.extended_signature if isinstance(module, dspy.ChainOfThought) else module.signature
         self.original_forward = module.forward
         self.new_signature = self._create_new_signature(self.original_signature)


### PR DESCRIPTION
# Description
`Retry` seems to drop all demos when wrapping a `Predict` instance.

Attempting to fix that